### PR TITLE
Development tech 576

### DIFF
--- a/backup_transport_dropbox.pl
+++ b/backup_transport_dropbox.pl
@@ -184,7 +184,7 @@ sub my_mkdir {
 
     if ($dropbox->error) {
         my $json = JSON::XS->new->ascii->decode($dropbox->error);
-        if ( $json->{'error_summary'} =~ s@^1path/conflict/folder@@ ) {
+        if ( $json->{'error_summary'} =~ s@1path/conflict/folder@@ ) {
              return;
         } else {
             print STDERR $dropbox->error;

--- a/backup_transport_dropbox.pl
+++ b/backup_transport_dropbox.pl
@@ -184,7 +184,7 @@ sub my_mkdir {
 
     if ($dropbox->error) {
         my $json = JSON::XS->new->ascii->decode($dropbox->error);
-        if ( $json->{'error_summary'} =~ s@1path/conflict/folder@@ ) {
+        if ( $json->{'error_summary'} =~ s@^path/conflict/folder@@ ) {
              return;
         } else {
             print STDERR $dropbox->error;

--- a/backup_transport_dropbox.pl
+++ b/backup_transport_dropbox.pl
@@ -14,7 +14,7 @@ use warnings;
 use IO::File;
 use WebService::Dropbox;
 
-our $VERSION = '1.01';
+our $VERSION = '1.02';
 
 # Create and setup our dropbox object
 my $dropbox = WebService::Dropbox->new({


### PR DESCRIPTION
push TECH-576 fix to development branch
#5 

When a backup path is provided, if multiple validation attempts are made, the transport system always issues a mkdir. This causes dropbox to throw "409 path/conflict/folder/".

In the mkdir subroutine, we capture the error and if it matches "^path/conflict/folder/", we ignore it, else we return it.